### PR TITLE
Shorten dotenv import (no need for config call)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { config } from "dotenv"
-config()
+import "dotenv/config"
 import { logger } from "./logger"
 
 export const greet = (thing: string) => `Hello ${thing}`


### PR DESCRIPTION
There's no need for `import { config } from "dotenv"; config();`, they thought of that and made `dotenv/config` an importable file that does everything for you